### PR TITLE
parse xlsx without xl/sharedStrings.xml

### DIFF
--- a/lib/xlsx_parser/xlsx_util.ex
+++ b/lib/xlsx_parser/xlsx_util.ex
@@ -6,6 +6,7 @@ defmodule XlsxParser.XlsxUtil do
     path
     |> get_raw_content("xl/sharedStrings.xml", zip)
     |> case do
+      {:error, :file_not_found} -> {:ok, []}
       {:error, reason} -> {:error, reason}
       {:ok, content}   ->
         ret = content


### PR DESCRIPTION
I work with `xlsx` that do not have file `xl/sharedStrings.xml`.
This PR allows parse them.