### PR TITLE
Now export closer to the standard CSV files

### DIFF
--- a/lib/xlsx_parser/xlsx_util.ex
+++ b/lib/xlsx_parser/xlsx_util.ex
@@ -48,6 +48,19 @@ defmodule XlsxParser.XlsxUtil do
     end
   end
 
+  defp escape_field(data) when not is_binary(data) do
+	data
+  end
+  defp escape_field(data) when is_binary(data) do
+	String.replace(data,"\\","\\\\")
+	|>String.replace("\"","\\\"")
+	|>(fn str -> "\""<>str<>"\"" end).()
+  end
+
+  defp escape_strings(row) do
+	  Enum.map(row,&escape_field(&1))
+  end
+
   @spec col_row_vals_to_csv([XmlParser.col_row_val]) :: String.t
   def col_row_vals_to_csv(col_row_vals) do
     col_row_vals
@@ -58,7 +71,8 @@ defmodule XlsxParser.XlsxUtil do
                           |> expand(to_num(col), "") #Ensure there are as many columns as the new column's index
                           |> List.replace_at(to_num(col) - 1, text) #put the new value in the new row
                           List.replace_at(acc, row - 1, new_row) #replace the old row with the new row
-                        end)
+						end)
+	|> Enum.map(&escape_strings(&1))
     |> Enum.reduce("", fn row, acc ->
                         acc <> Enum.join(row, ",") <> "\n"
                        end)

--- a/test/xlsx_parser_test.exs
+++ b/test/xlsx_parser_test.exs
@@ -36,7 +36,7 @@ defmodule XlsxParserTest do
   defmodule FileMock do
     def write(loc, content) do
       assert loc == "/path/to/my.csv"
-      assert content == "a,d\ntwo,three\nc,f\n"
+      assert content == "\"a\",\"d\"\n\"two\",\"three\"\n\"c\",\"f\"\n"
       :ok
     end
   end
@@ -44,7 +44,7 @@ defmodule XlsxParserTest do
   test "write_sheet_content_to_csv success" do
     {status, ret} = XlsxParser.write_sheet_content_to_csv("/path/to/my.xlsx", 1, "/path/to/my.csv", ZipMock, FileMock)
     assert status == :ok
-    assert ret == "a,d\ntwo,three\nc,f\n"
+    assert ret == "\"a\",\"d\"\n\"two\",\"three\"\n\"c\",\"f\"\n"
   end
 
   defmodule FileMockFail do


### PR DESCRIPTION
Made the export fix the issue #8 by adding quotes on both sides of strings and escaping \ characters to \\ and " characters to \"