### PR TITLE
Add support for formatted shared strings

### DIFF
--- a/lib/xlsx_parser/xml_parser.ex
+++ b/lib/xlsx_parser/xml_parser.ex
@@ -94,7 +94,7 @@ defmodule XlsxParser.XmlParser do
   @spec parse_shared_strings(String.t()) :: map
   def parse_shared_strings(xml) do
     xml
-    |> xpath(~x"//si/t"l)
+    |> xpath(~x"//si/t|//si/r/t"l)
     |> Enum.reduce(%{}, fn {:xmlElement, :t, :t, _, _, si, _, _, text_chunks, _, _, _}, acc ->
       text = chunks_to_text(text_chunks)
 

--- a/test/xlsx_parser_test.exs
+++ b/test/xlsx_parser_test.exs
@@ -11,7 +11,7 @@ defmodule XlsxParserTest do
     def zip_open(_, _), do: {:ok, SimpleAgent.start!()}
 
     def zip_get('xl/sharedStrings.xml', _),
-      do: {:ok, {:abc, '<sst><si><t>one</t></si><si><t>two</t></si><si><t>three</t></si></sst>'}}
+      do: {:ok, {:abc, '<sst><si><t>one</t></si><si><t>two</t></si><si><r><t>three</t></r></si></sst>'}}
 
     def zip_get('xl/worksheets/sheet1.xml', _),
       do:


### PR DESCRIPTION
This commit adds support for formatted shared strings. Their XML structure
is a bit different (<t> is placed under <r>) which must be take into
account in the XSLT query.

Close #11